### PR TITLE
Fix invalid order field names in help text and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Errors follow the same pattern — table mode prints `Error: ...` to stderr, JSO
 ```bash
 # List markets with filters
 polymarket markets list --limit 10
-polymarket markets list --active true --order volume_num
+polymarket markets list --active true --order volume
 polymarket markets list --closed false --limit 50 --offset 25
 
 # Get a single market by ID or slug

--- a/src/commands/markets.rs
+++ b/src/commands/markets.rs
@@ -42,7 +42,7 @@ pub enum MarketsCommand {
         #[arg(long)]
         offset: Option<i32>,
 
-        /// Sort field (e.g. `volume_num`, `liquidity_num`)
+        /// Sort field (e.g. `volume`, `liquidity`)
         #[arg(long)]
         order: Option<String>,
 


### PR DESCRIPTION
## Summary

- Fixes `--order volume_num` → `--order volume` in README example and CLI help text
- The API rejects `volume_num` and `liquidity_num` as order parameters with a 422 error; the valid values are `volume` and `liquidity`

## Root cause

`volume_num` and `liquidity_num` are field names on the Market response object (used for display), but the API `/markets` endpoint expects `volume` and `liquidity` as `order` query parameter values. The README and CLI help text were using the response field names instead of the query parameter names.

## Test plan

- [x] `cargo test` — all tests pass
- [x] `polymarket markets list --active true --order volume` returns results
- [x] `polymarket markets list --active true --order volume_num` returns 422 (before fix, this was the documented usage)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/help-text only; no runtime logic changes beyond the displayed usage guidance.
> 
> **Overview**
> Fixes `markets list --order` documentation to use API-valid sort fields: updates the README example and the CLI flag help text from `volume_num`/`liquidity_num` to `volume`/`liquidity` to avoid 422 errors from the `/markets` endpoint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13065103e775328585c96eced78178913680b03f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->