### PR TITLE
Fix Homebrew formula and auto-update on release

### DIFF
--- a/Formula/polymarket.rb
+++ b/Formula/polymarket.rb
@@ -1,30 +1,30 @@
 class Polymarket < Formula
   desc "CLI for Polymarket — browse markets, trade, and manage positions"
   homepage "https://github.com/Polymarket/polymarket-cli"
-  version "0.1.0"
+  version "0.1.4"
   license "MIT"
 
   on_macos do
     on_intel do
       url "https://github.com/Polymarket/polymarket-cli/releases/download/v#{version}/polymarket-v#{version}-x86_64-apple-darwin.tar.gz"
-      sha256 "REPLACE_WITH_SHA256"
+      sha256 "ec1dee1e1b7a66e8d2fc60ceb5e212b9f78e403b8079759a3b29b885cc4bb7ef"
     end
 
     on_arm do
       url "https://github.com/Polymarket/polymarket-cli/releases/download/v#{version}/polymarket-v#{version}-aarch64-apple-darwin.tar.gz"
-      sha256 "REPLACE_WITH_SHA256"
+      sha256 "c054c298417340d23995aa1181a2e47eea5bf7cb335c5417eb78e714fc433ac9"
     end
   end
 
   on_linux do
     on_intel do
       url "https://github.com/Polymarket/polymarket-cli/releases/download/v#{version}/polymarket-v#{version}-x86_64-unknown-linux-gnu.tar.gz"
-      sha256 "REPLACE_WITH_SHA256"
+      sha256 "b9f70ad1e3553de8a6546025ea1c7d14d69d51949c7609cac4cf8d9c686baa72"
     end
 
     on_arm do
       url "https://github.com/Polymarket/polymarket-cli/releases/download/v#{version}/polymarket-v#{version}-aarch64-unknown-linux-gnu.tar.gz"
-      sha256 "REPLACE_WITH_SHA256"
+      sha256 "4c94f152404483cdfe6fa3fed60b633a36f2fc813f3ee78091e6046423144292"
     end
   end
 


### PR DESCRIPTION
## Summary

Updates `Formula/polymarket.rb` from the placeholder template (v0.1.0 + `REPLACE_WITH_SHA256`) to v0.1.4 with verified checksums so `brew install polymarket` works immediately.

The release workflow auto-update added in bc7349d will keep it current going forward, but the formula needs this one-time fix to point at a real release.

Fixes #7
Fixes #2

## Changes

| File | Change |
|------|--------|
| `Formula/polymarket.rb` | Version → 0.1.4, real SHA256 values for all 4 targets |

## Test plan

- [ ] `brew tap Polymarket/polymarket-cli https://github.com/Polymarket/polymarket-cli && brew install polymarket` installs v0.1.4 successfully

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Auto-pushing formula changes from CI adds some repo-integrity risk if the workflow or checksum fetch fails/misbehaves, though the change is localized to release automation and packaging metadata.
> 
> **Overview**
> Updates the Homebrew formula `Formula/polymarket.rb` to point at CLI `v0.1.4` and replaces the placeholder `REPLACE_WITH_SHA256` values with real checksums for macOS (x86_64/arm64) and Linux (x86_64/arm64) tarballs.
> 
> Extends the GitHub Actions release workflow to auto-update the formula on each tagged release by generating `checksums.txt`, running `scripts/update-formula.sh` to rewrite the formula with the new version/hashes, and committing the result back to `main`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a2b8d231ef50e6454a96a87d558e2a881c7e2bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->