### PR TITLE
fix: correct sort order default to descending (#17)

### DIFF
--- a/src/commands/comments.rs
+++ b/src/commands/comments.rs
@@ -112,7 +112,7 @@ pub async fn execute(
                 .limit(limit)
                 .maybe_offset(offset)
                 .maybe_order(order)
-                .maybe_ascending(if ascending { Some(true) } else { None })
+                .maybe_ascending(Some(ascending))
                 .build();
 
             let comments = client.comments(&request).await?;
@@ -150,7 +150,7 @@ pub async fn execute(
                 .limit(limit)
                 .maybe_offset(offset)
                 .maybe_order(order)
-                .maybe_ascending(if ascending { Some(true) } else { None })
+                .maybe_ascending(Some(ascending))
                 .build();
 
             let comments = client.comments_by_user_address(&request).await?;

--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -79,7 +79,7 @@ pub async fn execute(client: &gamma::Client, args: EventsArgs, output: OutputFor
                 .limit(limit)
                 .maybe_closed(resolved_closed)
                 .maybe_offset(offset)
-                .maybe_ascending(if ascending { Some(true) } else { None })
+                .maybe_ascending(Some(ascending))
                 .maybe_tag_slug(tag)
                 .order(order.into_iter().collect::<Vec<_>>())
                 .build();

--- a/src/commands/markets.rs
+++ b/src/commands/markets.rs
@@ -95,7 +95,7 @@ pub async fn execute(
                 .maybe_closed(resolved_closed)
                 .maybe_offset(offset)
                 .maybe_order(order)
-                .maybe_ascending(if ascending { Some(true) } else { None })
+                .maybe_ascending(Some(ascending))
                 .build();
 
             let markets = client.markets(&request).await?;

--- a/src/commands/series.rs
+++ b/src/commands/series.rs
@@ -59,7 +59,7 @@ pub async fn execute(client: &gamma::Client, args: SeriesArgs, output: OutputFor
                 .limit(limit)
                 .maybe_offset(offset)
                 .maybe_order(order)
-                .maybe_ascending(if ascending { Some(true) } else { None })
+                .maybe_ascending(Some(ascending))
                 .maybe_closed(closed)
                 .build();
 


### PR DESCRIPTION
PR for fixing #17 

Changed the default sort direction from ascending to descending in both commands:

- Without `--ascending` flag: Results sort in descending order (default)
- With `--ascending` flag: Results sort in ascending order (explicit override)
- Changes
- Updated `markets.rs` MarketsCommand::List behavior
- Updated `events.rs` EventsCommand::List behavior
- This aligns the actual behavior with the existing help text and fixes issue #17.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to request construction for list endpoints; risk is limited to potentially changing default ordering behavior in CLI output.
> 
> **Overview**
> Fixes list-command sort direction handling by always sending an explicit `ascending` value to the SDK.
> 
> Across `comments`, `events`, `markets`, and `series` list flows, `maybe_ascending` now receives `Some(ascending)` instead of `None` when the flag is not set, aligning behavior with the CLI help text (default descending unless `--ascending` is provided).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed08ace9be45429daab521a810260ffd9c17f806. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->