### PR TITLE
fix: use derive_safe_wallet instead of derive_proxy_wallet for default proxy derivation

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -13,7 +13,7 @@ pub const RPC_URL: &str = "https://polygon.drpc.org";
 
 fn parse_signature_type(s: &str) -> SignatureType {
     match s {
-        config::DEFAULT_SIGNATURE_TYPE => SignatureType::Proxy,
+        "proxy" => SignatureType::Proxy,
         "gnosis-safe" => SignatureType::GnosisSafe,
         _ => SignatureType::Eoa,
     }

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -5,9 +5,9 @@ use std::str::FromStr;
 use anyhow::{Context, Result};
 use polymarket_client_sdk::auth::{LocalSigner, Signer as _};
 use polymarket_client_sdk::types::Address;
-use polymarket_client_sdk::{POLYGON, derive_proxy_wallet, derive_safe_wallet};
+use polymarket_client_sdk::POLYGON;
 
-use super::wallet::normalize_key;
+use super::wallet::{derive_wallet_for_type, normalize_key};
 use crate::config;
 
 fn print_banner() {
@@ -156,11 +156,7 @@ fn finish_setup(address: Address, signature_type: &str) -> Result<()> {
 
     step_header(2, total, "Proxy Wallet");
 
-    let proxy = match signature_type {
-        "proxy" => derive_proxy_wallet(address, POLYGON),
-        "gnosis-safe" => derive_safe_wallet(address, POLYGON),
-        _ => None,
-    };
+    let proxy = derive_wallet_for_type(address, POLYGON, signature_type);
     match proxy {
         Some(proxy) => {
             println!("  ✓ Proxy wallet derived");

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use anyhow::{Context, Result};
 use polymarket_client_sdk::auth::{LocalSigner, Signer as _};
 use polymarket_client_sdk::types::Address;
-use polymarket_client_sdk::{POLYGON, derive_proxy_wallet};
+use polymarket_client_sdk::{POLYGON, derive_safe_wallet};
 
 use super::wallet::normalize_key;
 use crate::config;
@@ -156,7 +156,7 @@ fn finish_setup(address: Address) -> Result<()> {
 
     step_header(2, total, "Proxy Wallet");
 
-    let proxy = derive_proxy_wallet(address, POLYGON);
+    let proxy = derive_safe_wallet(address, POLYGON);
     match proxy {
         Some(proxy) => {
             println!("  ✓ Proxy wallet derived");

--- a/src/commands/wallet.rs
+++ b/src/commands/wallet.rs
@@ -16,7 +16,7 @@ use crate::output::OutputFormat;
 /// - `"proxy"` → EIP-1167 proxy wallet
 /// - `"gnosis-safe"` → Gnosis Safe wallet
 /// - `"eoa"` / other → `None` (no proxy wallet)
-fn derive_wallet_for_type(
+pub(crate) fn derive_wallet_for_type(
     address: Address,
     chain_id: u64,
     signature_type: &str,

--- a/src/commands/wallet.rs
+++ b/src/commands/wallet.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result, bail};
 use clap::{Args, Subcommand};
 use polymarket_client_sdk::auth::LocalSigner;
 use polymarket_client_sdk::auth::Signer as _;
-use polymarket_client_sdk::{POLYGON, derive_proxy_wallet};
+use polymarket_client_sdk::{POLYGON, derive_safe_wallet};
 
 use crate::config;
 use crate::output::OutputFormat;
@@ -23,8 +23,8 @@ pub enum WalletCommand {
         /// Overwrite existing wallet
         #[arg(long)]
         force: bool,
-        /// Signature type: eoa, proxy (default), or gnosis-safe
-        #[arg(long, default_value = "proxy")]
+        /// Signature type: eoa, proxy, or gnosis-safe (default)
+        #[arg(long, default_value = "gnosis-safe")]
         signature_type: String,
     },
     /// Import an existing private key
@@ -34,8 +34,8 @@ pub enum WalletCommand {
         /// Overwrite existing wallet
         #[arg(long)]
         force: bool,
-        /// Signature type: eoa, proxy (default), or gnosis-safe
-        #[arg(long, default_value = "proxy")]
+        /// Signature type: eoa, proxy, or gnosis-safe (default)
+        #[arg(long, default_value = "gnosis-safe")]
         signature_type: String,
     },
     /// Show the address of the configured wallet
@@ -103,7 +103,7 @@ fn cmd_create(output: &OutputFormat, force: bool, signature_type: &str) -> Resul
 
     config::save_wallet(&key_hex, POLYGON, signature_type)?;
     let config_path = config::config_path()?;
-    let proxy_addr = derive_proxy_wallet(address, POLYGON);
+    let proxy_addr = derive_safe_wallet(address, POLYGON);
 
     match output {
         OutputFormat::Json => {
@@ -144,7 +144,7 @@ fn cmd_import(key: &str, output: &OutputFormat, force: bool, signature_type: &st
 
     config::save_wallet(&normalized, POLYGON, signature_type)?;
     let config_path = config::config_path()?;
-    let proxy_addr = derive_proxy_wallet(address, POLYGON);
+    let proxy_addr = derive_safe_wallet(address, POLYGON);
 
     match output {
         OutputFormat::Json => {
@@ -195,7 +195,7 @@ fn cmd_show(output: &OutputFormat, private_key_flag: Option<&str>) -> Result<()>
     let address = signer.as_ref().map(|s| s.address().to_string());
     let proxy_addr = signer
         .as_ref()
-        .and_then(|s| derive_proxy_wallet(s.address(), POLYGON))
+        .and_then(|s| derive_safe_wallet(s.address(), POLYGON))
         .map(|a| a.to_string());
 
     let sig_type = config::resolve_signature_type(None);

--- a/src/commands/wallet.rs
+++ b/src/commands/wallet.rs
@@ -5,10 +5,28 @@ use anyhow::{Context, Result, bail};
 use clap::{Args, Subcommand};
 use polymarket_client_sdk::auth::LocalSigner;
 use polymarket_client_sdk::auth::Signer as _;
-use polymarket_client_sdk::{POLYGON, derive_safe_wallet};
+use polymarket_client_sdk::types::Address;
+use polymarket_client_sdk::{POLYGON, derive_proxy_wallet, derive_safe_wallet};
 
 use crate::config;
 use crate::output::OutputFormat;
+
+/// Derive the appropriate proxy/safe wallet address based on signature type.
+///
+/// - `"proxy"` → EIP-1167 proxy wallet
+/// - `"gnosis-safe"` → Gnosis Safe wallet
+/// - `"eoa"` / other → `None` (no proxy wallet)
+fn derive_wallet_for_type(
+    address: Address,
+    chain_id: u64,
+    signature_type: &str,
+) -> Option<Address> {
+    match signature_type {
+        "proxy" => derive_proxy_wallet(address, chain_id),
+        "gnosis-safe" => derive_safe_wallet(address, chain_id),
+        _ => None,
+    }
+}
 
 #[derive(Args)]
 pub struct WalletArgs {
@@ -103,7 +121,7 @@ fn cmd_create(output: &OutputFormat, force: bool, signature_type: &str) -> Resul
 
     config::save_wallet(&key_hex, POLYGON, signature_type)?;
     let config_path = config::config_path()?;
-    let proxy_addr = derive_safe_wallet(address, POLYGON);
+    let proxy_addr = derive_wallet_for_type(address, POLYGON, signature_type);
 
     match output {
         OutputFormat::Json => {
@@ -144,7 +162,7 @@ fn cmd_import(key: &str, output: &OutputFormat, force: bool, signature_type: &st
 
     config::save_wallet(&normalized, POLYGON, signature_type)?;
     let config_path = config::config_path()?;
-    let proxy_addr = derive_safe_wallet(address, POLYGON);
+    let proxy_addr = derive_wallet_for_type(address, POLYGON, signature_type);
 
     match output {
         OutputFormat::Json => {
@@ -193,12 +211,11 @@ fn cmd_show(output: &OutputFormat, private_key_flag: Option<&str>) -> Result<()>
     let (key, source) = config::resolve_key(private_key_flag);
     let signer = key.as_deref().and_then(|k| LocalSigner::from_str(k).ok());
     let address = signer.as_ref().map(|s| s.address().to_string());
+    let sig_type = config::resolve_signature_type(None);
     let proxy_addr = signer
         .as_ref()
-        .and_then(|s| derive_safe_wallet(s.address(), POLYGON))
+        .and_then(|s| derive_wallet_for_type(s.address(), POLYGON, &sig_type))
         .map(|a| a.to_string());
-
-    let sig_type = config::resolve_signature_type(None);
     let config_path = config::config_path()?;
 
     match output {

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 const ENV_VAR: &str = "POLYMARKET_PRIVATE_KEY";
 const SIG_TYPE_ENV_VAR: &str = "POLYMARKET_SIGNATURE_TYPE";
-pub const DEFAULT_SIGNATURE_TYPE: &str = "proxy";
+pub const DEFAULT_SIGNATURE_TYPE: &str = "gnosis-safe";
 
 pub const NO_WALLET_MSG: &str =
     "No wallet configured. Run `polymarket wallet create` or `polymarket wallet import <key>`";


### PR DESCRIPTION
## Summary

- Replace `derive_proxy_wallet` (EIP-1167) with `derive_safe_wallet` (Gnosis Safe) as the default proxy wallet derivation
- Change `DEFAULT_SIGNATURE_TYPE` from `"proxy"` to `"gnosis-safe"`
- Users can still pass `--signature-type proxy` for Magic Link accounts

## Problem

The CLI derives the proxy wallet address using `derive_proxy_wallet()` (EIP-1167 minimal proxy, factory `0xaB45...`), but Polymarket deploys **Gnosis Safe** wallets (factory `0xaacF...`) for browser wallet users. The two derivation methods use different salt encoding, factory addresses, and init code hashes, producing completely different addresses for the same EOA.

This causes:
- `wallet show` displaying the wrong proxy address
- `clob balance` returning 0 (querying wrong address)
- `approve set` approving the wrong address
- `setup` wizard directing users to deposit to the wrong address

## Changes

| File | Change |
|------|--------|
| `src/config.rs` | `DEFAULT_SIGNATURE_TYPE`: `"proxy"` → `"gnosis-safe"` |
| `src/commands/wallet.rs` | `derive_proxy_wallet` → `derive_safe_wallet`; default `--signature-type` → `"gnosis-safe"` |
| `src/commands/setup.rs` | `derive_proxy_wallet` → `derive_safe_wallet` |
| `src/auth.rs` | Decouple `parse_signature_type` from `DEFAULT_SIGNATURE_TYPE` constant to prevent incorrect mapping |

## Verification

```bash
# After the fix, the derived proxy address matches the API:
polymarket wallet show -o json        # proxy_address field
polymarket profiles get <eoa> -o json # proxyWallet field
# These two now return the same address.
```

## Test plan

- [x] `cargo test` — all 143 tests pass (94 unit + 49 integration)
- [x] `polymarket wallet show` displays the correct Gnosis Safe proxy address
- [x] `polymarket clob balance` returns the actual balance
- [ ] `--signature-type proxy` still works for Magic Link accounts

Fixes #14

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CLI’s default signature type and derived funding/approval address, which can affect where users deposit funds and what address gets approved. Risk is moderated by still allowing explicit `--signature-type` overrides but misconfiguration could still lead to wrong addresses shown/used.
> 
> **Overview**
> Updates the CLI to default `signature_type` to **`gnosis-safe`** (`DEFAULT_SIGNATURE_TYPE` and `wallet create/import` defaults), aligning derived “proxy wallet” addresses with Gnosis Safe instead of EIP-1167 proxies.
> 
> Introduces `derive_wallet_for_type` and wires it through `wallet show/create/import` and the `setup` wizard so the displayed/deposit proxy address matches the selected signature type, and simplifies auth signature-type parsing to map explicit strings (e.g., `"proxy"`, `"gnosis-safe"`) rather than depending on the default constant.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9255cad95969b9f4817573ea7e97c0d72bfb6fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->