### PR TITLE
feat: add --watch flag for real-time auto-refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4094,6 +4094,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4433,6 +4443,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 polymarket-client-sdk = { version = "0.4", features = ["gamma", "data", "bridge", "clob", "ctf"] }
 alloy = { version = "1.6.3", default-features = false, features = ["providers", "sol-types", "contract", "reqwest", "reqwest-rustls-tls", "signer-local", "signers"] }
 clap = { version = "4", features = ["derive"] }
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 tabled = "0.17"

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -486,3 +486,30 @@ fn wallet_address_succeeds_or_fails_gracefully() {
     // Either succeeds or fails with an error message — not a panic
     assert!(output.status.success() || !output.stderr.is_empty());
 }
+
+#[test]
+fn watch_flag_appears_in_help() {
+    polymarket()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--watch"));
+}
+
+#[test]
+fn watch_with_json_output_rejected() {
+    polymarket()
+        .args(["--watch", "5", "-o", "json", "wallet", "show"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--watch is not supported with JSON"));
+}
+
+#[test]
+fn watch_zero_interval_rejected() {
+    polymarket()
+        .args(["--watch", "0", "wallet", "show"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("at least 1 second"));
+}


### PR DESCRIPTION
## Summary
- Adds a global `--watch <SECONDS>` flag that re-runs any command at a configurable interval with screen clearing
- Enables live monitoring of prices, orderbooks, orders, positions, and other data
- Rejects `--watch` with JSON output mode and zero-second intervals with clear error messages
- Clean Ctrl+C exit handling via `tokio::signal`

## Usage
```bash
polymarket --watch 5 clob price <TOKEN> --side buy   # refresh price every 5s
polymarket --watch 3 clob book <TOKEN>               # live orderbook
polymarket --watch 10 clob orders                    # monitor open orders
polymarket --watch 10 data positions <ADDR>          # track portfolio
```

## Implementation
- ~25 lines of new logic in `src/main.rs` only — zero changes to command or output modules
- No new crate dependencies (only adds `"signal"` feature to existing `tokio`)
- Global flag follows existing `--output` pattern via clap `global = true`

## Test plan
- [x] `cargo build` compiles without errors
- [x] `cargo test` — all 146 tests pass (94 unit + 52 integration), including 3 new tests
- [x] `--watch` appears in `--help` output
- [x] `--watch` with `-o json` is rejected with error
- [x] `--watch 0` is rejected with error
- [x] Manual: `cargo run -- --watch 3 status` refreshes every 3s, Ctrl+C exits cleanly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an opt-in CLI loop around existing command execution plus a `tokio` feature flag, with no changes to business logic or data/auth flows.
> 
> **Overview**
> Adds a global `--watch <seconds>` flag to re-run the selected CLI command on an interval, clearing the screen and showing a timestamped header each refresh.
> 
> `--watch` is explicitly rejected for JSON output and for a `0` interval, and uses `tokio::signal::ctrl_c()` to exit cleanly. Integration tests cover help output and the validation errors, and `tokio` is built with the `signal` feature (updating `Cargo.lock` accordingly).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 994a15be4a932f0a9ff07e00dc922db101cec209. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->