### PR TITLE
feat: add --descending flag to all list commands

### DIFF
--- a/src/commands/comments.rs
+++ b/src/commands/comments.rs
@@ -41,9 +41,13 @@ pub enum CommentsCommand {
         #[arg(long)]
         order: Option<String>,
 
-        /// Sort ascending instead of descending
-        #[arg(long)]
+        /// Sort ascending
+        #[arg(long, conflicts_with = "descending")]
         ascending: bool,
+
+        /// Sort descending
+        #[arg(long, conflicts_with = "ascending")]
+        descending: bool,
     },
 
     /// Get a comment by ID
@@ -69,9 +73,13 @@ pub enum CommentsCommand {
         #[arg(long)]
         order: Option<String>,
 
-        /// Sort ascending instead of descending
-        #[arg(long)]
+        /// Sort ascending
+        #[arg(long, conflicts_with = "descending")]
         ascending: bool,
+
+        /// Sort descending
+        #[arg(long, conflicts_with = "ascending")]
+        descending: bool,
     },
 }
 
@@ -105,14 +113,21 @@ pub async fn execute(
             offset,
             order,
             ascending,
+            descending,
         } => {
+            let sort_ascending = match (ascending, descending) {
+                (true, _) => Some(true),
+                (_, true) => Some(false),
+                _ => None,
+            };
+
             let request = CommentsRequest::builder()
                 .parent_entity_type(ParentEntityType::from(entity_type))
                 .parent_entity_id(entity_id)
                 .limit(limit)
                 .maybe_offset(offset)
                 .maybe_order(order)
-                .maybe_ascending(if ascending { Some(true) } else { None })
+                .maybe_ascending(sort_ascending)
                 .build();
 
             let comments = client.comments(&request).await?;
@@ -143,14 +158,21 @@ pub async fn execute(
             offset,
             order,
             ascending,
+            descending,
         } => {
+            let sort_ascending = match (ascending, descending) {
+                (true, _) => Some(true),
+                (_, true) => Some(false),
+                _ => None,
+            };
+
             let addr = parse_address(&address)?;
             let request = CommentsByUserAddressRequest::builder()
                 .user_address(addr)
                 .limit(limit)
                 .maybe_offset(offset)
                 .maybe_order(order)
-                .maybe_ascending(if ascending { Some(true) } else { None })
+                .maybe_ascending(sort_ascending)
                 .build();
 
             let comments = client.comments_by_user_address(&request).await?;

--- a/src/commands/series.rs
+++ b/src/commands/series.rs
@@ -30,9 +30,13 @@ pub enum SeriesCommand {
         #[arg(long)]
         order: Option<String>,
 
-        /// Sort ascending instead of descending
-        #[arg(long)]
+        /// Sort ascending
+        #[arg(long, conflicts_with = "descending")]
         ascending: bool,
+
+        /// Sort descending
+        #[arg(long, conflicts_with = "ascending")]
+        descending: bool,
 
         /// Filter by closed status
         #[arg(long)]
@@ -53,13 +57,20 @@ pub async fn execute(client: &gamma::Client, args: SeriesArgs, output: OutputFor
             offset,
             order,
             ascending,
+            descending,
             closed,
         } => {
+            let sort_ascending = match (ascending, descending) {
+                (true, _) => Some(true),
+                (_, true) => Some(false),
+                _ => None,
+            };
+
             let request = SeriesListRequest::builder()
                 .limit(limit)
                 .maybe_offset(offset)
                 .maybe_order(order)
-                .maybe_ascending(if ascending { Some(true) } else { None })
+                .maybe_ascending(sort_ascending)
                 .maybe_closed(closed)
                 .build();
 

--- a/src/commands/sports.rs
+++ b/src/commands/sports.rs
@@ -33,9 +33,13 @@ pub enum SportsCommand {
         #[arg(long)]
         order: Option<String>,
 
-        /// Sort ascending instead of descending
-        #[arg(long)]
+        /// Sort ascending
+        #[arg(long, conflicts_with = "descending")]
         ascending: bool,
+
+        /// Sort descending
+        #[arg(long, conflicts_with = "ascending")]
+        descending: bool,
 
         /// Filter by league
         #[arg(long)]
@@ -68,13 +72,20 @@ pub async fn execute(client: &gamma::Client, args: SportsArgs, output: OutputFor
             offset,
             order,
             ascending,
+            descending,
             league,
         } => {
+            let sort_ascending = match (ascending, descending) {
+                (true, _) => Some(true),
+                (_, true) => Some(false),
+                _ => None,
+            };
+
             let request = TeamsRequest::builder()
                 .limit(limit)
                 .maybe_offset(offset)
                 .maybe_order(order)
-                .maybe_ascending(if ascending { Some(true) } else { None })
+                .maybe_ascending(sort_ascending)
                 .league(league.into_iter().collect::<Vec<_>>())
                 .build();
 

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -30,9 +30,13 @@ pub enum TagsCommand {
         #[arg(long)]
         offset: Option<i32>,
 
-        /// Sort ascending instead of descending
-        #[arg(long)]
+        /// Sort ascending
+        #[arg(long, conflicts_with = "descending")]
         ascending: bool,
+
+        /// Sort descending
+        #[arg(long, conflicts_with = "ascending")]
+        descending: bool,
     },
 
     /// Get a single tag by ID or slug
@@ -68,11 +72,18 @@ pub async fn execute(client: &gamma::Client, args: TagsArgs, output: OutputForma
             limit,
             offset,
             ascending,
+            descending,
         } => {
+            let sort_ascending = match (ascending, descending) {
+                (true, _) => Some(true),
+                (_, true) => Some(false),
+                _ => None,
+            };
+
             let request = TagsRequest::builder()
                 .limit(limit)
                 .maybe_offset(offset)
-                .maybe_ascending(if ascending { Some(true) } else { None })
+                .maybe_ascending(sort_ascending)
                 .build();
 
             let tags = client.tags(&request).await?;


### PR DESCRIPTION
The --ascending flag was the only sort direction control, but omitting it just deferred to the API default there was no way to explicitly request descending sort. Add a --descending counterpart (mutually exclusive via conflicts_with) so users can opt into either direction.

No flag omits the parameter entirely, preserving existing behavior.

Closes #17

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CLI behavior change that only affects optional sort-direction query parameters; default behavior is preserved when no flag is provided.
> 
> **Overview**
> Adds an explicit `--descending` flag (mutually exclusive with `--ascending`) to all relevant `list`-style commands so users can force descending sort rather than relying on API defaults.
> 
> Updates request construction to derive a single optional sort-direction value (`Some(true)`, `Some(false)`, or `None`) and pass it through `maybe_ascending`, and adds unit tests in `markets` to verify the query string omits the parameter when unset and encodes `ascending=true/false` when either flag is used.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8e4636b10ab36ecd44df134d9ef1230a7443ab1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->