### PR TITLE
Fix ascending sort flag to properly control sort direction

### DIFF
--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -79,7 +79,7 @@ pub async fn execute(client: &gamma::Client, args: EventsArgs, output: OutputFor
                 .limit(limit)
                 .maybe_closed(resolved_closed)
                 .maybe_offset(offset)
-                .maybe_ascending(if ascending { Some(true) } else { None })
+                .maybe_ascending(Some(ascending))
                 .maybe_tag_slug(tag)
                 .order(order.into_iter().collect::<Vec<_>>())
                 .build();

--- a/src/commands/markets.rs
+++ b/src/commands/markets.rs
@@ -95,7 +95,7 @@ pub async fn execute(
                 .maybe_closed(resolved_closed)
                 .maybe_offset(offset)
                 .maybe_order(order)
-                .maybe_ascending(if ascending { Some(true) } else { None })
+                .maybe_ascending(Some(ascending))
                 .build();
 
             let markets = client.markets(&request).await?;


### PR DESCRIPTION
Fixes #17.

The --ascending flag was previously a no-op because the code passed None when ascending was false, which caused the API to use its default (ascending) behavior regardless of the flag.

Changed to explicitly pass Some(ascending) so that:
- Without --ascending flag: descending order (ascending=false)
- With --ascending flag: ascending order (ascending=true)

This matches the help text implication that ascending should sort "instead of" descending, making descending the default.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to request-building for list commands; only affects sorting behavior and does not touch auth or data mutation.
> 
> **Overview**
> Fixes the CLI `--ascending` sort flag for `events list` and `markets list` by always sending an explicit boolean to the API (`maybe_ascending(Some(ascending))`) instead of omitting the parameter when false.
> 
> This makes descending the effective default when the flag isn’t provided, and only requests ascending order when `--ascending` is set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea9c00d98c149694b13e8a4e1f40c9347c7ee111. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->