### PR TITLE
fix: `--ascending` flag made explicit, default descending

### DIFF
--- a/src/commands/comments.rs
+++ b/src/commands/comments.rs
@@ -112,7 +112,7 @@ pub async fn execute(
                 .limit(limit)
                 .maybe_offset(offset)
                 .maybe_order(order)
-                .maybe_ascending(if ascending { Some(true) } else { None })
+                .maybe_ascending(Some(ascending))
                 .build();
 
             let comments = client.comments(&request).await?;
@@ -150,7 +150,7 @@ pub async fn execute(
                 .limit(limit)
                 .maybe_offset(offset)
                 .maybe_order(order)
-                .maybe_ascending(if ascending { Some(true) } else { None })
+                .maybe_ascending(Some(ascending))
                 .build();
 
             let comments = client.comments_by_user_address(&request).await?;

--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -79,7 +79,7 @@ pub async fn execute(client: &gamma::Client, args: EventsArgs, output: OutputFor
                 .limit(limit)
                 .maybe_closed(resolved_closed)
                 .maybe_offset(offset)
-                .maybe_ascending(if ascending { Some(true) } else { None })
+                .maybe_ascending(Some(ascending))
                 .maybe_tag_slug(tag)
                 .order(order.into_iter().collect::<Vec<_>>())
                 .build();

--- a/src/commands/markets.rs
+++ b/src/commands/markets.rs
@@ -95,7 +95,7 @@ pub async fn execute(
                 .maybe_closed(resolved_closed)
                 .maybe_offset(offset)
                 .maybe_order(order)
-                .maybe_ascending(if ascending { Some(true) } else { None })
+                .maybe_ascending(Some(ascending))
                 .build();
 
             let markets = client.markets(&request).await?;

--- a/src/commands/series.rs
+++ b/src/commands/series.rs
@@ -59,7 +59,7 @@ pub async fn execute(client: &gamma::Client, args: SeriesArgs, output: OutputFor
                 .limit(limit)
                 .maybe_offset(offset)
                 .maybe_order(order)
-                .maybe_ascending(if ascending { Some(true) } else { None })
+                .maybe_ascending(Some(ascending))
                 .maybe_closed(closed)
                 .build();
 

--- a/src/commands/sports.rs
+++ b/src/commands/sports.rs
@@ -74,7 +74,7 @@ pub async fn execute(client: &gamma::Client, args: SportsArgs, output: OutputFor
                 .limit(limit)
                 .maybe_offset(offset)
                 .maybe_order(order)
-                .maybe_ascending(if ascending { Some(true) } else { None })
+                .maybe_ascending(Some(ascending))
                 .league(league.into_iter().collect::<Vec<_>>())
                 .build();
 

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -72,7 +72,7 @@ pub async fn execute(client: &gamma::Client, args: TagsArgs, output: OutputForma
             let request = TagsRequest::builder()
                 .limit(limit)
                 .maybe_offset(offset)
-                .maybe_ascending(if ascending { Some(true) } else { None })
+                .maybe_ascending(Some(ascending))
                 .build();
 
             let tags = client.tags(&request).await?;


### PR DESCRIPTION
Fixes #17 
Patching PR #20 #31, related to #26 

The default behavior of descending sort remains (no ascending flag), fix up all instances to `maybe_ascending(Some(ascending))` across all 6 references.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, mechanical change limited to query parameter construction for list endpoints; no auth, persistence, or data mutation paths are affected.
> 
> **Overview**
> Fixes sorting behavior in CLI list commands by always forwarding the `ascending` flag into the SDK request builders (`maybe_ascending(Some(ascending))`) instead of only setting it when `--ascending` is true.
> 
> This updates the request construction for comments, events, markets, series, sports teams, and tags so ascending/descending ordering is applied consistently.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcbc50b897706c29aac425624b161c7cbf864fda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->