### PR TITLE
feat: add shell completion support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,6 +1258,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c757a3b7e39161a4e56f9365141ada2a6c915a8622c408ab6bb4b5d047371031"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1798,7 +1807,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2973,6 +2982,7 @@ dependencies = [
  "assert_cmd",
  "chrono",
  "clap",
+ "clap_complete",
  "dirs",
  "polymarket-client-sdk",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 polymarket-client-sdk = { version = "0.4", features = ["gamma", "data", "bridge", "clob", "ctf"] }
 alloy = { version = "1.6.3", default-features = false, features = ["providers", "sol-types", "contract", "reqwest", "reqwest-rustls-tls", "signer-local", "signers"] }
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,8 @@ mod shell;
 
 use std::process::ExitCode;
 
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
+use clap_complete::Shell;
 use output::OutputFormat;
 
 #[derive(Parser)]
@@ -64,6 +65,11 @@ enum Commands {
     Status,
     /// Update to the latest version
     Upgrade,
+    /// Generate shell completions
+    Completions {
+        /// Shell to generate completions for
+        shell: Shell,
+    },
 }
 
 #[tokio::main]
@@ -117,6 +123,15 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             commands::wallet::execute(args, cli.output, cli.private_key.as_deref())
         }
         Commands::Upgrade => commands::upgrade::execute(),
+        Commands::Completions { shell } => {
+            clap_complete::generate(
+                shell,
+                &mut Cli::command(),
+                "polymarket",
+                &mut std::io::stdout(),
+            );
+            Ok(())
+        }
         Commands::Status => {
             let status = gamma.status().await?;
             match cli.output {


### PR DESCRIPTION
## Summary

Adds a `polymarket completions <shell>` subcommand that generates shell completion scripts using `clap_complete`.

Fixes #34

## Usage

```bash
# Bash
polymarket completions bash >> ~/.bashrc

# Zsh
polymarket completions zsh >> ~/.zshrc

# Fish
polymarket completions fish > ~/.config/fish/completions/polymarket.fish
```

Supported shells: `bash`, `zsh`, `fish`, `elvish`, `powershell`.

## Changes

| File | Change |
|------|--------|
| `Cargo.toml` | Add `clap_complete = "4"` dependency |
| `src/main.rs` | Add `Completions` subcommand with `Shell` argument and `clap_complete::generate` handler |

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all 131 tests pass (82 unit + 49 integration)
- [x] `polymarket completions bash` outputs valid completion script
- [x] `polymarket completions zsh` outputs valid completion script

This contribution was developed with AI assistance (Claude Code).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an optional CLI subcommand and a dependency; no changes to trading/auth flows or data handling.
> 
> **Overview**
> Adds a new `polymarket completions <shell>` subcommand that prints shell completion scripts to stdout via `clap_complete::generate`.
> 
> Wires in the new `clap_complete` dependency (and lockfile updates) and updates CLI parsing to expose `Shell` as an argument for completion generation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc5cbfbf643c4504d5779d57df316071fba423d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->