### PR TITLE
fix(data): include missing fields in activity output

### DIFF
--- a/src/output/data.rs
+++ b/src/output/data.rs
@@ -257,10 +257,16 @@ pub fn print_activity(activity: &[Activity], output: &OutputFormat) -> anyhow::R
             struct Row {
                 #[tabled(rename = "Type")]
                 activity_type: String,
+                #[tabled(rename = "Side")]
+                side: String,
                 #[tabled(rename = "Market")]
                 title: String,
+                #[tabled(rename = "Outcome")]
+                outcome: String,
                 #[tabled(rename = "Size")]
                 size: String,
+                #[tabled(rename = "Price")]
+                price: String,
                 #[tabled(rename = "USDC")]
                 usdc_size: String,
                 #[tabled(rename = "Tx")]
@@ -270,8 +276,16 @@ pub fn print_activity(activity: &[Activity], output: &OutputFormat) -> anyhow::R
                 .iter()
                 .map(|a| Row {
                     activity_type: a.activity_type.to_string(),
+                    side: a
+                        .side
+                        .as_ref()
+                        .map_or_else(|| DASH.to_string(), ToString::to_string),
                     title: truncate(a.title.as_deref().unwrap_or(DASH), 35),
+                    outcome: truncate(a.outcome.as_deref().unwrap_or(DASH), 10),
                     size: format!("{:.2}", a.size),
+                    price: a
+                        .price
+                        .map_or_else(|| DASH.to_string(), |p| format!("{p:.4}")),
                     usdc_size: format_decimal(a.usdc_size),
                     tx: truncate(&a.transaction_hash.to_string(), 14),
                 })
@@ -285,9 +299,16 @@ pub fn print_activity(activity: &[Activity], output: &OutputFormat) -> anyhow::R
                 .map(|a| {
                     json!({
                         "activity_type": a.activity_type.to_string(),
+                        "side": a.side.as_ref().map(ToString::to_string),
                         "title": a.title,
+                        "outcome": a.outcome,
+                        "outcome_index": a.outcome_index,
                         "size": a.size.to_string(),
+                        "price": a.price.map(|p| p.to_string()),
                         "usdc_size": a.usdc_size.to_string(),
+                        "asset": a.asset.map(|v| v.to_string()),
+                        "condition_id": a.condition_id.map(|c| c.to_string()),
+                        "slug": a.slug,
                         "timestamp": a.timestamp,
                         "transaction_hash": a.transaction_hash.to_string(),
                         "proxy_wallet": a.proxy_wallet.to_string(),


### PR DESCRIPTION
## Summary

Adds missing fields to `polymarket data activity` output that are present in the underlying REST API (`https://data-api.polymarket.com/activity`).

Fixes #29

## Fields added

| Field | JSON output | Table output |
|-------|-------------|--------------|
| `side` | `"BUY"` / `"SELL"` / `null` | Side column |
| `price` | `"0.55"` / `null` | Price column |
| `outcome` | `"Yes"` / `"No"` / `null` | Outcome column |
| `outcome_index` | `0` / `1` / `null` | - |
| `asset` | token ID string / `null` | - |
| `condition_id` | `"0xdc2a..."` / `null` | - |
| `slug` | `"market-slug"` / `null` | - |

The `side` field is critical for distinguishing buys from sells in non-CLOB activity records, which was the core issue reported.

## Changes

| File | Change |
|------|--------|
| `src/output/data.rs` | Add 7 fields to JSON output, add Side/Outcome/Price columns to table output |

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all 131 tests pass

This contribution was developed with AI assistance (Claude Code).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Output-only changes that add fields/columns without altering request logic or persistence; risk is limited to minor formatting/compatibility impacts for consumers parsing the CLI output.
> 
> **Overview**
> Updates `print_activity` output to surface previously omitted activity metadata.
> 
> Table output now includes new `Side`, `Outcome`, and `Price` columns (with `-` for missing values), and JSON output now includes `side`, `outcome`, `outcome_index`, `price`, `asset`, `condition_id`, and `slug` fields in addition to the existing activity data.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6baffee3b32f8b9b23ae9bfb92b378cb7a792ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->