### PR TITLE
fix: omit ascending param when unset, default to descending

### DIFF
--- a/src/commands/comments.rs
+++ b/src/commands/comments.rs
@@ -112,7 +112,7 @@ pub async fn execute(
                 .limit(limit)
                 .maybe_offset(offset)
                 .maybe_order(order)
-                .ascending(ascending)
+                .maybe_ascending(if ascending { Some(true) } else { None })
                 .build();
 
             let comments = client.comments(&request).await?;
@@ -142,7 +142,7 @@ pub async fn execute(
                 .limit(limit)
                 .maybe_offset(offset)
                 .maybe_order(order)
-                .ascending(ascending)
+                .maybe_ascending(if ascending { Some(true) } else { None })
                 .build();
 
             let comments = client.comments_by_user_address(&request).await?;

--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -79,7 +79,7 @@ pub async fn execute(client: &gamma::Client, args: EventsArgs, output: OutputFor
                 .limit(limit)
                 .maybe_closed(resolved_closed)
                 .maybe_offset(offset)
-                .ascending(ascending)
+                .maybe_ascending(if ascending { Some(true) } else { None })
                 .maybe_tag_slug(tag)
                 // EventsRequest::order is Vec<String>; into_iter on Option yields 0 or 1 items.
                 .order(order.into_iter().collect())

--- a/src/commands/markets.rs
+++ b/src/commands/markets.rs
@@ -95,7 +95,7 @@ pub async fn execute(
                 .maybe_closed(resolved_closed)
                 .maybe_offset(offset)
                 .maybe_order(order)
-                .ascending(ascending)
+                .maybe_ascending(if ascending { Some(true) } else { None })
                 .build();
 
             let markets = client.markets(&request).await?;

--- a/src/commands/series.rs
+++ b/src/commands/series.rs
@@ -59,7 +59,7 @@ pub async fn execute(client: &gamma::Client, args: SeriesArgs, output: OutputFor
                 .limit(limit)
                 .maybe_offset(offset)
                 .maybe_order(order)
-                .ascending(ascending)
+                .maybe_ascending(if ascending { Some(true) } else { None })
                 .maybe_closed(closed)
                 .build();
 

--- a/src/commands/sports.rs
+++ b/src/commands/sports.rs
@@ -66,7 +66,7 @@ pub async fn execute(client: &gamma::Client, args: SportsArgs, output: OutputFor
                 .limit(limit)
                 .maybe_offset(offset)
                 .maybe_order(order)
-                .ascending(ascending)
+                .maybe_ascending(if ascending { Some(true) } else { None })
                 .league(league.into_iter().collect())
                 .build();
 

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -72,7 +72,7 @@ pub async fn execute(client: &gamma::Client, args: TagsArgs, output: OutputForma
             let request = TagsRequest::builder()
                 .limit(limit)
                 .maybe_offset(offset)
-                .ascending(ascending)
+                .maybe_ascending(if ascending { Some(true) } else { None })
                 .build();
 
             let tags = client.tags(&request).await?;


### PR DESCRIPTION
## Summary

- When `--ascending` is not passed, the CLI was sending `ascending=false` to the Gamma API, which overrode the server's default descending sort
- Changed all 7 call sites (markets, events, series, tags, comments, sports) to use `.maybe_ascending()` so the parameter is only included when the user explicitly requests ascending order
- This lets the API return results in its natural descending order by default

Fixes #17

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (131 tests)
- [ ] `polymarket markets list` returns newest markets first (descending)
- [ ] `polymarket markets list --ascending` returns oldest first

This contribution was developed with AI assistance (Claude Code).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, mechanical change to request parameter construction; main risk is behavior change in default sort order for list commands.
> 
> **Overview**
> Fixes list endpoints in the CLI to **stop sending `ascending=false` by default**, which previously overrode the Gamma API’s default (descending) sort.
> 
> Across comments, events, markets, series, sports teams, and tags list commands, request builders switch from `.ascending(ascending)` to `.maybe_ascending(...)`, so the `ascending` parameter is only included when the user passes `--ascending`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6da0e56f9db8a018ca7b75e30b60e99fbdccc71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->