### PR TITLE
feat(cli): add explicit --descending sort flag

### DIFF
--- a/src/commands/comments.rs
+++ b/src/commands/comments.rs
@@ -42,8 +42,12 @@ pub enum CommentsCommand {
         order: Option<String>,
 
         /// Sort ascending instead of descending
-        #[arg(long)]
+        #[arg(long, conflicts_with = "descending")]
         ascending: bool,
+
+        /// Sort descending (explicit counterpart to --ascending)
+        #[arg(long, conflicts_with = "ascending")]
+        descending: bool,
     },
 
     /// Get a comment by ID
@@ -70,8 +74,12 @@ pub enum CommentsCommand {
         order: Option<String>,
 
         /// Sort ascending instead of descending
-        #[arg(long)]
+        #[arg(long, conflicts_with = "descending")]
         ascending: bool,
+
+        /// Sort descending (explicit counterpart to --ascending)
+        #[arg(long, conflicts_with = "ascending")]
+        descending: bool,
     },
 }
 
@@ -105,6 +113,7 @@ pub async fn execute(
             offset,
             order,
             ascending,
+            descending,
         } => {
             let request = CommentsRequest::builder()
                 .parent_entity_type(ParentEntityType::from(entity_type))
@@ -112,7 +121,7 @@ pub async fn execute(
                 .limit(limit)
                 .maybe_offset(offset)
                 .maybe_order(order)
-                .ascending(ascending)
+                .ascending(if descending { false } else { ascending })
                 .build();
 
             let comments = client.comments(&request).await?;
@@ -136,13 +145,14 @@ pub async fn execute(
             offset,
             order,
             ascending,
+            descending,
         } => {
             let request = CommentsByUserAddressRequest::builder()
                 .user_address(address)
                 .limit(limit)
                 .maybe_offset(offset)
                 .maybe_order(order)
-                .ascending(ascending)
+                .ascending(if descending { false } else { ascending })
                 .build();
 
             let comments = client.comments_by_user_address(&request).await?;

--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -41,8 +41,12 @@ pub enum EventsCommand {
         order: Option<String>,
 
         /// Sort ascending instead of descending
-        #[arg(long)]
+        #[arg(long, conflicts_with = "descending")]
         ascending: bool,
+
+        /// Sort descending (explicit counterpart to --ascending)
+        #[arg(long, conflicts_with = "ascending")]
+        descending: bool,
 
         /// Filter by tag slug (e.g. "politics", "crypto")
         #[arg(long)]
@@ -71,6 +75,7 @@ pub async fn execute(client: &gamma::Client, args: EventsArgs, output: OutputFor
             offset,
             order,
             ascending,
+            descending,
             tag,
         } => {
             let resolved_closed = closed.or_else(|| active.map(|a| !a));
@@ -79,7 +84,7 @@ pub async fn execute(client: &gamma::Client, args: EventsArgs, output: OutputFor
                 .limit(limit)
                 .maybe_closed(resolved_closed)
                 .maybe_offset(offset)
-                .ascending(ascending)
+                .ascending(if descending { false } else { ascending })
                 .maybe_tag_slug(tag)
                 // EventsRequest::order is Vec<String>; into_iter on Option yields 0 or 1 items.
                 .order(order.into_iter().collect())

--- a/src/commands/markets.rs
+++ b/src/commands/markets.rs
@@ -47,8 +47,12 @@ pub enum MarketsCommand {
         order: Option<String>,
 
         /// Sort ascending instead of descending
-        #[arg(long)]
+        #[arg(long, conflicts_with = "descending")]
         ascending: bool,
+
+        /// Sort descending (explicit counterpart to --ascending)
+        #[arg(long, conflicts_with = "ascending")]
+        descending: bool,
     },
 
     /// Get a single market by ID or slug
@@ -87,6 +91,7 @@ pub async fn execute(
             offset,
             order,
             ascending,
+            descending,
         } => {
             let resolved_closed = closed.or_else(|| active.map(|a| !a));
 
@@ -95,7 +100,7 @@ pub async fn execute(
                 .maybe_closed(resolved_closed)
                 .maybe_offset(offset)
                 .maybe_order(order)
-                .ascending(ascending)
+                .ascending(if descending { false } else { ascending })
                 .build();
 
             let markets = client.markets(&request).await?;

--- a/src/commands/series.rs
+++ b/src/commands/series.rs
@@ -31,8 +31,12 @@ pub enum SeriesCommand {
         order: Option<String>,
 
         /// Sort ascending instead of descending
-        #[arg(long)]
+        #[arg(long, conflicts_with = "descending")]
         ascending: bool,
+
+        /// Sort descending (explicit counterpart to --ascending)
+        #[arg(long, conflicts_with = "ascending")]
+        descending: bool,
 
         /// Filter by closed status
         #[arg(long)]
@@ -53,13 +57,14 @@ pub async fn execute(client: &gamma::Client, args: SeriesArgs, output: OutputFor
             offset,
             order,
             ascending,
+            descending,
             closed,
         } => {
             let request = SeriesListRequest::builder()
                 .limit(limit)
                 .maybe_offset(offset)
                 .maybe_order(order)
-                .ascending(ascending)
+                .ascending(if descending { false } else { ascending })
                 .maybe_closed(closed)
                 .build();
 

--- a/src/commands/sports.rs
+++ b/src/commands/sports.rs
@@ -34,8 +34,12 @@ pub enum SportsCommand {
         order: Option<String>,
 
         /// Sort ascending instead of descending
-        #[arg(long)]
+        #[arg(long, conflicts_with = "descending")]
         ascending: bool,
+
+        /// Sort descending (explicit counterpart to --ascending)
+        #[arg(long, conflicts_with = "ascending")]
+        descending: bool,
 
         /// Filter by league
         #[arg(long)]
@@ -60,13 +64,14 @@ pub async fn execute(client: &gamma::Client, args: SportsArgs, output: OutputFor
             offset,
             order,
             ascending,
+            descending,
             league,
         } => {
             let request = TeamsRequest::builder()
                 .limit(limit)
                 .maybe_offset(offset)
                 .maybe_order(order)
-                .ascending(ascending)
+                .ascending(if descending { false } else { ascending })
                 .league(league.into_iter().collect())
                 .build();
 

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -31,8 +31,12 @@ pub enum TagsCommand {
         offset: Option<i32>,
 
         /// Sort ascending instead of descending
-        #[arg(long)]
+        #[arg(long, conflicts_with = "descending")]
         ascending: bool,
+
+        /// Sort descending (explicit counterpart to --ascending)
+        #[arg(long, conflicts_with = "ascending")]
+        descending: bool,
     },
 
     /// Get a single tag by ID or slug
@@ -68,11 +72,12 @@ pub async fn execute(client: &gamma::Client, args: TagsArgs, output: OutputForma
             limit,
             offset,
             ascending,
+            descending,
         } => {
             let request = TagsRequest::builder()
                 .limit(limit)
                 .maybe_offset(offset)
-                .ascending(ascending)
+                .ascending(if descending { false } else { ascending })
                 .build();
 
             let tags = client.tags(&request).await?;


### PR DESCRIPTION
Addresses #17

## Summary
- Add explicit `--descending` flag as counterpart to existing `--ascending`.
- Make the flags mutually exclusive via clap `conflicts_with`.
- Apply to all list-style commands with sort direction:
  - markets list
  - events list
  - series list
  - sports teams
  - tags list
  - comments list / comments by-user

## Notes
- Behaviour stays backward-compatible: default remains descending.
- This only improves CLI ergonomics and discoverability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CLI-only change: adds a new `--descending` flag and makes sort-direction flags mutually exclusive without changing default behavior.
> 
> **Overview**
> Adds an explicit `--descending` CLI flag (mutually exclusive with `--ascending`) across list-style commands (`markets`, `events`, `series`, `sports teams`, `tags`, and `comments`).
> 
> Updates request construction so `--descending` forces `ascending=false` while preserving the existing default of descending sort when neither flag is provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63fa9a1338bfbadf6d82a512226941cd386e93f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->