### PR TITLE
feat: expose volume, liquidity, date, and tag filters on list commands

### DIFF
--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -1,9 +1,11 @@
 use anyhow::Result;
+use chrono::{DateTime, Utc};
 use clap::{Args, Subcommand};
 use polymarket_client_sdk::gamma::{
     self,
     types::request::{EventByIdRequest, EventBySlugRequest, EventTagsRequest, EventsRequest},
 };
+use rust_decimal::Decimal;
 
 use super::is_numeric_id;
 use crate::output::OutputFormat;
@@ -47,6 +49,38 @@ pub enum EventsCommand {
         /// Filter by tag slug (e.g. "politics", "crypto")
         #[arg(long)]
         tag: Option<String>,
+
+        /// Minimum trading volume (e.g. 1000000)
+        #[arg(long)]
+        volume_min: Option<Decimal>,
+
+        /// Maximum trading volume
+        #[arg(long)]
+        volume_max: Option<Decimal>,
+
+        /// Minimum liquidity
+        #[arg(long)]
+        liquidity_min: Option<Decimal>,
+
+        /// Maximum liquidity
+        #[arg(long)]
+        liquidity_max: Option<Decimal>,
+
+        /// Only events starting after this date (e.g. 2026-03-01T00:00:00Z)
+        #[arg(long)]
+        start_date_min: Option<DateTime<Utc>>,
+
+        /// Only events starting before this date
+        #[arg(long)]
+        start_date_max: Option<DateTime<Utc>>,
+
+        /// Only events ending after this date
+        #[arg(long)]
+        end_date_min: Option<DateTime<Utc>>,
+
+        /// Only events ending before this date
+        #[arg(long)]
+        end_date_max: Option<DateTime<Utc>>,
     },
 
     /// Get a single event by ID or slug
@@ -72,6 +106,14 @@ pub async fn execute(client: &gamma::Client, args: EventsArgs, output: OutputFor
             order,
             ascending,
             tag,
+            volume_min,
+            volume_max,
+            liquidity_min,
+            liquidity_max,
+            start_date_min,
+            start_date_max,
+            end_date_min,
+            end_date_max,
         } => {
             let resolved_closed = closed.or_else(|| active.map(|a| !a));
 
@@ -83,6 +125,14 @@ pub async fn execute(client: &gamma::Client, args: EventsArgs, output: OutputFor
                 .maybe_tag_slug(tag)
                 // EventsRequest::order is Vec<String>; into_iter on Option yields 0 or 1 items.
                 .order(order.into_iter().collect())
+                .maybe_volume_min(volume_min)
+                .maybe_volume_max(volume_max)
+                .maybe_liquidity_min(liquidity_min)
+                .maybe_liquidity_max(liquidity_max)
+                .maybe_start_date_min(start_date_min)
+                .maybe_start_date_max(start_date_max)
+                .maybe_end_date_min(end_date_min)
+                .maybe_end_date_max(end_date_max)
                 .build();
 
             let events = client.events(&request).await?;

--- a/src/commands/markets.rs
+++ b/src/commands/markets.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use chrono::{DateTime, Utc};
 use clap::{Args, Subcommand};
 use polymarket_client_sdk::gamma::{
     self,
@@ -10,6 +11,7 @@ use polymarket_client_sdk::gamma::{
         response::Market,
     },
 };
+use rust_decimal::Decimal;
 
 use super::is_numeric_id;
 use crate::output::OutputFormat;
@@ -49,6 +51,42 @@ pub enum MarketsCommand {
         /// Sort ascending instead of descending
         #[arg(long)]
         ascending: bool,
+
+        /// Minimum trading volume (e.g. 1000000)
+        #[arg(long)]
+        volume_min: Option<Decimal>,
+
+        /// Maximum trading volume
+        #[arg(long)]
+        volume_max: Option<Decimal>,
+
+        /// Minimum liquidity
+        #[arg(long)]
+        liquidity_min: Option<Decimal>,
+
+        /// Maximum liquidity
+        #[arg(long)]
+        liquidity_max: Option<Decimal>,
+
+        /// Only markets starting after this date (e.g. 2026-03-01T00:00:00Z)
+        #[arg(long)]
+        start_date_min: Option<DateTime<Utc>>,
+
+        /// Only markets starting before this date
+        #[arg(long)]
+        start_date_max: Option<DateTime<Utc>>,
+
+        /// Only markets ending after this date
+        #[arg(long)]
+        end_date_min: Option<DateTime<Utc>>,
+
+        /// Only markets ending before this date
+        #[arg(long)]
+        end_date_max: Option<DateTime<Utc>>,
+
+        /// Filter by tag ID
+        #[arg(long)]
+        tag: Option<String>,
     },
 
     /// Get a single market by ID or slug
@@ -87,6 +125,15 @@ pub async fn execute(
             offset,
             order,
             ascending,
+            volume_min,
+            volume_max,
+            liquidity_min,
+            liquidity_max,
+            start_date_min,
+            start_date_max,
+            end_date_min,
+            end_date_max,
+            tag,
         } => {
             let resolved_closed = closed.or_else(|| active.map(|a| !a));
 
@@ -96,6 +143,15 @@ pub async fn execute(
                 .maybe_offset(offset)
                 .maybe_order(order)
                 .ascending(ascending)
+                .maybe_volume_num_min(volume_min)
+                .maybe_volume_num_max(volume_max)
+                .maybe_liquidity_num_min(liquidity_min)
+                .maybe_liquidity_num_max(liquidity_max)
+                .maybe_start_date_min(start_date_min)
+                .maybe_start_date_max(start_date_max)
+                .maybe_end_date_min(end_date_min)
+                .maybe_end_date_max(end_date_max)
+                .maybe_tag_id(tag)
                 .build();
 
             let markets = client.markets(&request).await?;


### PR DESCRIPTION
## Summary

- Wires through volume, liquidity, date range, and tag filter params that the SDK already supports but `markets list` and `events list` weren't exposing
- Users no longer need to over-fetch and filter client-side to find specific markets

Closes #38

## New flags on `markets list` and `events list`

| Flag | Description |
|------|-------------|
| `--volume-min` / `--volume-max` | filter by trading volume |
| `--liquidity-min` / `--liquidity-max` | filter by liquidity |
| `--start-date-min` / `--start-date-max` | filter by start date |
| `--end-date-min` / `--end-date-max` | filter by end date |
| `--tag` | filter by tag ID (markets) or tag slug (events, already existed) |

## Example

```bash
# find high-volume markets created this month
polymarket markets list --volume-min 1000000 --start-date-min 2026-03-01T00:00:00Z
```

## Test plan

- [x] `cargo test` — 131 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Verified `--help` output shows new flags correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds new CLI flags and forwards them into existing SDK request builders without changing core business logic or data writes.
> 
> **Overview**
> Adds new filtering flags to `events list` and `markets list` for volume and liquidity ranges plus start/end date ranges, wiring them through to the underlying `EventsRequest`/`MarketsRequest` builders.
> 
> Also exposes a `--tag` filter on `markets list` (tag ID) and keeps `events list` tag filtering (tag slug), enabling server-side filtering instead of client-side post-processing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf8f3668a4a31bdfa0803075e353d9ef9b2f86c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->