### PR TITLE
fix: auto-refresh balance cache on stale-balance order failures

### DIFF
--- a/src/commands/clob.rs
+++ b/src/commands/clob.rs
@@ -485,6 +485,11 @@ fn parse_date(s: &str) -> Result<NaiveDate> {
         .map_err(|_| anyhow::anyhow!("Invalid date: expected YYYY-MM-DD format"))
 }
 
+/// detect the CLOB "not enough balance / allowance" error so we can refresh and retry
+fn is_balance_error(e: &polymarket_client_sdk::error::Error) -> bool {
+    e.to_string().contains("not enough balance")
+}
+
 #[allow(clippy::too_many_lines)]
 pub async fn execute(
     args: ClobArgs,
@@ -676,18 +681,44 @@ pub async fn execute(
             let size_dec =
                 Decimal::from_str(&size).map_err(|_| anyhow::anyhow!("Invalid size: {size}"))?;
 
+            let sdk_side = Side::from(side);
+            let sdk_order_type = OrderType::from(order_type);
+            let token_id = parse_token_id(&token)?;
+
             let order = client
                 .limit_order()
-                .token_id(parse_token_id(&token)?)
-                .side(Side::from(side))
+                .token_id(token_id)
+                .side(sdk_side)
                 .price(price_dec)
                 .size(size_dec)
-                .order_type(OrderType::from(order_type))
+                .order_type(sdk_order_type.clone())
                 .post_only(post_only)
                 .build()
                 .await?;
             let order = client.sign(&signer, order).await?;
-            let result = client.post_order(order).await?;
+            let result = match client.post_order(order).await {
+                Ok(r) => r,
+                Err(e) if is_balance_error(&e) => {
+                    eprintln!("Balance cache may be stale, refreshing and retrying...");
+                    let req = BalanceAllowanceRequest::builder()
+                        .asset_type(AssetType::Collateral)
+                        .build();
+                    let _ = client.update_balance_allowance(req).await;
+                    let order = client
+                        .limit_order()
+                        .token_id(token_id)
+                        .side(sdk_side)
+                        .price(price_dec)
+                        .size(size_dec)
+                        .order_type(sdk_order_type)
+                        .post_only(post_only)
+                        .build()
+                        .await?;
+                    let order = client.sign(&signer, order).await?;
+                    client.post_order(order).await?
+                }
+                Err(e) => return Err(e.into()),
+            };
             print_post_order_result(&result, output)?;
         }
 
@@ -757,16 +788,39 @@ pub async fn execute(
                 Amount::usdc(amount_dec)?
             };
 
+            let sdk_order_type = OrderType::from(order_type);
+            let token_id = parse_token_id(&token)?;
+
             let order = client
                 .market_order()
-                .token_id(parse_token_id(&token)?)
+                .token_id(token_id)
                 .side(sdk_side)
                 .amount(parsed_amount)
-                .order_type(OrderType::from(order_type))
+                .order_type(sdk_order_type.clone())
                 .build()
                 .await?;
             let order = client.sign(&signer, order).await?;
-            let result = client.post_order(order).await?;
+            let result = match client.post_order(order).await {
+                Ok(r) => r,
+                Err(e) if is_balance_error(&e) => {
+                    eprintln!("Balance cache may be stale, refreshing and retrying...");
+                    let req = BalanceAllowanceRequest::builder()
+                        .asset_type(AssetType::Collateral)
+                        .build();
+                    let _ = client.update_balance_allowance(req).await;
+                    let order = client
+                        .market_order()
+                        .token_id(token_id)
+                        .side(sdk_side)
+                        .amount(parsed_amount)
+                        .order_type(sdk_order_type)
+                        .build()
+                        .await?;
+                    let order = client.sign(&signer, order).await?;
+                    client.post_order(order).await?
+                }
+                Err(e) => return Err(e.into()),
+            };
             print_post_order_result(&result, output)?;
         }
 


### PR DESCRIPTION
## Problem

FAK and FOK orders fail with `400 "not enough balance / allowance"` even when the user has sufficient USDC.e (#54). This happens because the CLOB server caches wallet balances — if the cache is stale (e.g. after a deposit, approval, or recent trade), the server rejects orders based on outdated balance data.

Users currently have to manually run `polymarket clob update-balance --asset-type collateral` before retrying, but nothing tells them to do that. The error message gives no indication that the balance is cached or that a refresh might help.

## Fix

When `post_order` fails with "not enough balance", the CLI now:

1. Calls `update_balance_allowance` to refresh the server's cached balance
2. Rebuilds the order (new salt for the fresh signature)
3. Re-signs and retries once

If the retry also fails, the original error propagates — so users with genuinely insufficient funds still get the correct error.

This applies to both `create-order` (limit orders) and `market-order` paths, covering all order types (GTC, GTD, FOK, FAK).

### Implementation

One file changed (`src/commands/clob.rs`):
- Added `is_balance_error()` helper that checks the SDK error message
- Wrapped `post_order` calls in `create-order` and `market-order` with retry-on-balance-error logic
- Converted CLI enums to SDK types once upfront so they can be reused on retry

## Test plan

- [x] `cargo test` — 131 tests pass (82 unit + 49 integration)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Verified wallet connection works with live CLOB (`clob balance` returns $690)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authenticated order submission paths and introduces automatic retry behavior, which could mask some error cases or add unexpected extra requests. Scope is limited to a single retry on a specific error string match.
> 
> **Overview**
> Improves CLI resiliency for `create-order` (limit) and `market-order` by detecting CLOB "not enough balance / allowance" failures, refreshing the server-side collateral balance cache via `update_balance_allowance`, then rebuilding/re-signing and retrying `post_order` once.
> 
> Refactors these paths to parse `token_id`, `Side`, and `OrderType` once up front so the same inputs can be reused on the retry, and adds an `is_balance_error` helper to gate the behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb38955e6bcc46a9a709f73548a3e117c44f0fd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->