### PR TITLE
feat: add shell completion support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,6 +1258,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1798,7 +1807,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2973,6 +2982,7 @@ dependencies = [
  "assert_cmd",
  "chrono",
  "clap",
+ "clap_complete",
  "dirs",
  "polymarket-client-sdk",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 polymarket-client-sdk = { version = "0.4", features = ["gamma", "data", "bridge", "clob", "ctf"] }
 alloy = { version = "1.6.3", default-features = false, features = ["providers", "sol-types", "contract", "reqwest", "reqwest-rustls-tls", "signer-local", "signers"] }
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ mod shell;
 
 use std::process::ExitCode;
 
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
 use output::OutputFormat;
 
 #[derive(Parser)]
@@ -64,6 +64,11 @@ enum Commands {
     Status,
     /// Update to the latest version
     Upgrade,
+    /// Generate shell completion scripts
+    Completion {
+        /// Shell type to generate completions for
+        shell: clap_complete::Shell,
+    },
 }
 
 #[tokio::main]
@@ -117,6 +122,10 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             commands::wallet::execute(args, cli.output, cli.private_key.as_deref())
         }
         Commands::Upgrade => commands::upgrade::execute(),
+        Commands::Completion { shell } => {
+            clap_complete::generate(shell, &mut Cli::command(), "polymarket", &mut std::io::stdout());
+            Ok(())
+        }
         Commands::Status => {
             let status = gamma.status().await?;
             match cli.output {


### PR DESCRIPTION
## Summary
Fixes #34

Adds shell completion script generation via a new `completion` subcommand, powered by `clap_complete`. Supports bash, zsh, fish, elvish, and powershell.

## Changes
- Add `clap_complete = "4"` dependency to `Cargo.toml`
- Add `Completion { shell }` subcommand to the `Commands` enum
- Generate completions to stdout using `clap_complete::generate()`

## Usage

```bash
# Generate completion script for your shell
polymarket completion bash > ~/.local/share/bash-completion/completions/polymarket
polymarket completion zsh  > ~/.zfunc/_polymarket
polymarket completion fish > ~/.config/fish/completions/polymarket.fish
```

## Testing
- `cargo build` — compiles cleanly
- `cargo test` — all 49 tests pass
- `cargo clippy` — no warnings
- Manually verified `polymarket completion bash` outputs a valid completion script

## Notes
- Minimal change: only 3 files touched (Cargo.toml, Cargo.lock, src/main.rs)
- No modifications to existing commands
- Uses the same `clap_complete` approach suggested in the issue

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new `completion` subcommand and dependency without changing existing command execution paths or any network/auth/data-handling logic.
> 
> **Overview**
> Adds shell completion generation to the CLI via a new `completion` subcommand that outputs `clap_complete` scripts to stdout.
> 
> This introduces the `clap_complete` dependency (and lockfile updates) and wires `Commands::Completion { shell }` to call `clap_complete::generate()` using the existing `clap` command definition.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3967881f60580dfa6e348ef9f156318446921da9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->