### PR TITLE
feat(data): add closed positions sorting and fix end_date output

### DIFF
--- a/src/commands/data.rs
+++ b/src/commands/data.rs
@@ -51,6 +51,14 @@ pub enum DataCommand {
         /// Pagination offset
         #[arg(long)]
         offset: Option<i32>,
+
+        /// Sort field: pnl, title, price, avg-price, timestamp
+        #[arg(long)]
+        sort_by: Option<ClosedPositionSortBy>,
+
+        /// Sort direction: asc, desc
+        #[arg(long, default_value = "desc")]
+        sort_dir: ClosedPositionSortDir,
     },
 
     /// Get total position value for a wallet address
@@ -191,6 +199,42 @@ impl From<OrderBy> for polymarket_client_sdk::data::types::LeaderboardOrderBy {
     }
 }
 
+#[derive(Clone, Debug, clap::ValueEnum)]
+pub enum ClosedPositionSortBy {
+    Pnl,
+    Title,
+    Price,
+    AvgPrice,
+    Timestamp,
+}
+
+impl From<ClosedPositionSortBy> for polymarket_client_sdk::data::types::ClosedPositionSortBy {
+    fn from(v: ClosedPositionSortBy) -> Self {
+        match v {
+            ClosedPositionSortBy::Pnl => Self::RealizedPnl,
+            ClosedPositionSortBy::Title => Self::Title,
+            ClosedPositionSortBy::Price => Self::Price,
+            ClosedPositionSortBy::AvgPrice => Self::AvgPrice,
+            ClosedPositionSortBy::Timestamp => Self::Timestamp,
+        }
+    }
+}
+
+#[derive(Clone, Debug, clap::ValueEnum)]
+pub enum ClosedPositionSortDir {
+    Asc,
+    Desc,
+}
+
+impl From<ClosedPositionSortDir> for polymarket_client_sdk::data::types::SortDirection {
+    fn from(v: ClosedPositionSortDir) -> Self {
+        match v {
+            ClosedPositionSortDir::Asc => Self::Asc,
+            ClosedPositionSortDir::Desc => Self::Desc,
+        }
+    }
+}
+
 pub async fn execute(client: &data::Client, args: DataArgs, output: OutputFormat) -> Result<()> {
     match args.command {
         DataCommand::Positions {
@@ -212,11 +256,15 @@ pub async fn execute(client: &data::Client, args: DataArgs, output: OutputFormat
             address,
             limit,
             offset,
+            sort_by,
+            sort_dir,
         } => {
             let request = ClosedPositionsRequest::builder()
                 .user(address)
                 .limit(limit)?
                 .maybe_offset(offset)?
+                .maybe_sort_by(sort_by.map(Into::into))
+                .sort_direction(sort_dir.into())
                 .build();
 
             let positions = client.closed_positions(&request).await?;

--- a/src/commands/data.rs
+++ b/src/commands/data.rs
@@ -259,13 +259,19 @@ pub async fn execute(client: &data::Client, args: DataArgs, output: OutputFormat
             sort_by,
             sort_dir,
         } => {
-            let request = ClosedPositionsRequest::builder()
+            let builder = ClosedPositionsRequest::builder()
                 .user(address)
                 .limit(limit)?
-                .maybe_offset(offset)?
-                .maybe_sort_by(sort_by.map(Into::into))
-                .sort_direction(sort_dir.into())
-                .build();
+                .maybe_offset(offset)?;
+
+            let request = if let Some(sort_by) = sort_by {
+                builder
+                    .sort_by(sort_by.into())
+                    .sort_direction(sort_dir.into())
+                    .build()
+            } else {
+                builder.build()
+            };
 
             let positions = client.closed_positions(&request).await?;
             print_closed_positions(&positions, &output)?;

--- a/src/output/data.rs
+++ b/src/output/data.rs
@@ -81,7 +81,7 @@ pub fn print_positions(positions: &[Position], output: &OutputFormat) -> anyhow:
                         "proxy_wallet": p.proxy_wallet.to_string(),
                         "redeemable": p.redeemable,
                         "mergeable": p.mergeable,
-                        "end_date": p.end_date.to_string(),
+                        "end_date": p.end_date.map(|d| d.to_string()),
                         "negative_risk": p.negative_risk,
                     })
                 })

--- a/src/output/data.rs
+++ b/src/output/data.rs
@@ -81,7 +81,7 @@ pub fn print_positions(positions: &[Position], output: &OutputFormat) -> anyhow:
                         "proxy_wallet": p.proxy_wallet.to_string(),
                         "redeemable": p.redeemable,
                         "mergeable": p.mergeable,
-                        "end_date": p.end_date.map(|d| d.to_string()),
+                        "end_date": p.end_date.to_string(),
                         "negative_risk": p.negative_risk,
                     })
                 })


### PR DESCRIPTION
Adds closed-positions sorting options (--sort-by, --sort-dir) and fixes JSON serialization for optional end_date by emitting null when absent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CLI change that only adds optional request parameters for sorting; behavior is unchanged unless users pass the new flags.
> 
> **Overview**
> Adds `--sort-by` and `--sort-dir` flags to the `data closed-positions` CLI command and maps them to the SDK’s `ClosedPositionsRequest` sorting fields.
> 
> Request construction is updated so sorting parameters are only sent when `--sort-by` is provided (with `--sort-dir` defaulting to `desc`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d824f7cde1ac1a4ef0d8fe2a2d5b3ede767bef6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->