### PR TITLE
fix: handle Option<NaiveDate> when serializing end_date

### DIFF
--- a/src/output/data.rs
+++ b/src/output/data.rs
@@ -81,7 +81,7 @@ pub fn print_positions(positions: &[Position], output: &OutputFormat) -> anyhow:
                         "proxy_wallet": p.proxy_wallet.to_string(),
                         "redeemable": p.redeemable,
                         "mergeable": p.mergeable,
-                        "end_date": p.end_date.to_string(),
+                        "end_date": p.end_date.map(|d| d.to_string()),
                         "negative_risk": p.negative_risk,
                     })
                 })


### PR DESCRIPTION
Fixes #65

`p.end_date` is `Option<NaiveDate>` so calling `.to_string()` directly fails to compile on stable Rust.

Verified with `cargo check` (0 errors).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to JSON formatting for a single field; main impact is that missing `end_date` now serializes as `null` instead of failing to compile.
> 
> **Overview**
> Fixes JSON serialization for `Position.end_date` in `print_positions` by converting it with `Option::map` instead of calling `.to_string()` directly.
> 
> This makes `end_date` emit as either a string date or `null` in the JSON output and restores compilation on stable Rust when `end_date` is `Option<NaiveDate>`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85494cc5ee8310a85071659e595ae77677fb7a5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->