### PR TITLE
fix: bump polymarket_client_sdk_v2 0.5.1 → 0.6.0-canary.1 (fixes #73)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ name = "polymarket"
 path = "src/main.rs"
 
 [dependencies]
-polymarket_client_sdk_v2 = { version = "0.5.1", features = ["gamma", "data", "bridge", "clob", "ctf"] }
+polymarket_client_sdk_v2 = { version = "0.6.0-canary.1", features = ["gamma", "data", "bridge", "clob", "ctf"] }
 alloy = { version = "1.6.3", default-features = false, features = ["providers", "rpc-types", "sol-types", "contract", "reqwest", "reqwest-rustls-tls", "signer-local", "signers"] }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }


### PR DESCRIPTION
Closing — superseded by #67 which was merged into `main` on 2026-05-26. That PR does a full SDK v2 migration (37 files). A new release cut from current `main` will fix the issue for all users.