### PR TITLE
fix(clob book): show best bid/ask at the top of the orderbook

### DIFF
--- a/src/output/clob/books.rs
+++ b/src/output/clob/books.rs
@@ -1,11 +1,27 @@
 use polymarket_client_sdk_v2::clob::types::response::{
-    LastTradePriceResponse, LastTradesPricesResponse, OrderBookSummaryResponse,
+    LastTradePriceResponse, LastTradesPricesResponse, OrderBookSummaryResponse, OrderSummary,
 };
 use serde_json::json;
 use tabled::settings::Style;
 use tabled::{Table, Tabled};
 
 use crate::output::{DASH, OutputFormat, truncate};
+
+/// Returns bids in display order (best bid first).
+///
+/// The CLOB API returns bids ascending by price, so the best (highest-priced)
+/// bid is reversed to the top for human-facing display.
+fn bids_in_display_order(bids: &[OrderSummary]) -> Vec<&OrderSummary> {
+    bids.iter().rev().collect()
+}
+
+/// Returns asks in display order (best ask first).
+///
+/// The CLOB API returns asks descending by price, so the best (lowest-priced)
+/// ask is reversed to the top for human-facing display.
+fn asks_in_display_order(asks: &[OrderSummary]) -> Vec<&OrderSummary> {
+    asks.iter().rev().collect()
+}
 
 pub fn print_order_book(
     result: &OrderBookSummaryResponse,
@@ -35,10 +51,8 @@ pub fn print_order_book(
                 println!("No bids.");
             } else {
                 println!("Bids:");
-                let rows: Vec<Row> = result
-                    .bids
-                    .iter()
-                    .rev()
+                let rows: Vec<Row> = bids_in_display_order(&result.bids)
+                    .into_iter()
                     .map(|o| Row {
                         price: o.price.to_string(),
                         size: o.size.to_string(),
@@ -54,10 +68,8 @@ pub fn print_order_book(
                 println!("No asks.");
             } else {
                 println!("Asks:");
-                let rows: Vec<Row> = result
-                    .asks
-                    .iter()
-                    .rev()
+                let rows: Vec<Row> = asks_in_display_order(&result.asks)
+                    .into_iter()
                     .map(|o| Row {
                         price: o.price.to_string(),
                         size: o.size.to_string(),
@@ -163,100 +175,54 @@ pub fn print_last_trades_prices(
 
 #[cfg(test)]
 mod tests {
-    use chrono::Utc;
-    use polymarket_client_sdk_v2::clob::types::TickSize;
-    use polymarket_client_sdk_v2::clob::types::response::{OrderBookSummaryResponse, OrderSummary};
-    use polymarket_client_sdk_v2::types::{B256, Decimal, U256};
+    use super::{OrderSummary, asks_in_display_order, bids_in_display_order};
     use rust_decimal_macros::dec;
 
-    /// Build a minimal `OrderBookSummaryResponse` with caller-supplied bids and asks.
-    /// The bids are provided in WORST-first order (ascending price) and asks in
-    /// WORST-first order (descending price), which is what a naïve API response might
-    /// contain and what the bug causes to be printed.
-    fn make_book(
-        bids: Vec<OrderSummary>,
-        asks: Vec<OrderSummary>,
-    ) -> OrderBookSummaryResponse {
-        OrderBookSummaryResponse::builder()
-            .market(B256::ZERO)
-            .asset_id(U256::ZERO)
-            .timestamp(Utc::now())
-            .min_order_size(dec!(1))
-            .neg_risk(false)
-            .tick_size(TickSize::Hundredth)
-            .bids(bids)
-            .asks(asks)
-            .build()
+    fn order(price: rust_decimal::Decimal) -> OrderSummary {
+        OrderSummary::builder().price(price).size(dec!(100)).build()
     }
 
-    fn make_order(price: Decimal, size: Decimal) -> OrderSummary {
-        OrderSummary::builder().price(price).size(size).build()
-    }
-
-    /// Returns the price strings in the order that `print_order_book` would render them,
-    /// mirroring the exact `.iter().rev().map(|o| o.price.to_string())` chain used in the
-    /// production function.
-    fn rendered_bid_prices(book: &OrderBookSummaryResponse) -> Vec<String> {
-        book.bids.iter().rev().map(|o| o.price.to_string()).collect()
-    }
-
-    fn rendered_ask_prices(book: &OrderBookSummaryResponse) -> Vec<String> {
-        book.asks.iter().rev().map(|o| o.price.to_string()).collect()
-    }
-
-    /// The first bid shown must be the BEST bid (highest price = 0.50).
-    /// The current code iterates in insertion order without sorting, so it
-    /// renders 0.30 first — causing this test to FAIL on unpatched code.
+    // The CLOB API returns bids ascending (worst price first).
+    // The display order helper must reverse that so the best (highest) bid is first.
     #[test]
-    fn bids_rendered_best_price_first() {
-        // Bids inserted worst-to-best (ascending price), as might come from the API.
-        let book = make_book(
-            vec![
-                make_order(dec!(0.30), dec!(100)),
-                make_order(dec!(0.40), dec!(100)),
-                make_order(dec!(0.50), dec!(100)),
-            ],
-            vec![
-                make_order(dec!(0.50), dec!(100)),
-                make_order(dec!(0.60), dec!(100)),
-                make_order(dec!(0.70), dec!(100)),
-            ],
-        );
+    fn bids_in_display_order_puts_best_bid_first() {
+        let api_order = vec![order(dec!(0.30)), order(dec!(0.40)), order(dec!(0.50))];
 
-        let bid_prices = rendered_bid_prices(&book);
+        let displayed: Vec<rust_decimal::Decimal> = bids_in_display_order(&api_order)
+            .into_iter()
+            .map(|o| o.price)
+            .collect();
+
         assert_eq!(
-            bid_prices[0], "0.50",
-            "first rendered bid must be the best (highest) bid price 0.50, got {} \
-             — bids are printed in insertion order without sorting",
-            bid_prices[0]
+            displayed,
+            vec![dec!(0.50), dec!(0.40), dec!(0.30)],
+            "bids must be reversed for display so the highest-priced bid is on top"
         );
     }
 
-    /// The first ask shown must be the BEST ask (lowest price = 0.50).
-    /// Current code iterates in insertion order — FAILS when asks are stored
-    /// worst-first (descending price).
+    // The CLOB API returns asks descending (worst price first).
+    // The display order helper must reverse that so the best (lowest) ask is first.
     #[test]
-    fn asks_rendered_best_price_first() {
-        // Asks inserted worst-to-best (descending price), as might come from the API.
-        let book = make_book(
-            vec![
-                make_order(dec!(0.30), dec!(100)),
-                make_order(dec!(0.40), dec!(100)),
-                make_order(dec!(0.50), dec!(100)),
-            ],
-            vec![
-                make_order(dec!(0.70), dec!(100)),
-                make_order(dec!(0.60), dec!(100)),
-                make_order(dec!(0.50), dec!(100)),
-            ],
-        );
+    fn asks_in_display_order_puts_best_ask_first() {
+        let api_order = vec![order(dec!(0.70)), order(dec!(0.60)), order(dec!(0.50))];
 
-        let ask_prices = rendered_ask_prices(&book);
+        let displayed: Vec<rust_decimal::Decimal> = asks_in_display_order(&api_order)
+            .into_iter()
+            .map(|o| o.price)
+            .collect();
+
         assert_eq!(
-            ask_prices[0], "0.50",
-            "first rendered ask must be the best (lowest) ask price 0.50, got {} \
-             — asks are printed in insertion order without sorting",
-            ask_prices[0]
+            displayed,
+            vec![dec!(0.50), dec!(0.60), dec!(0.70)],
+            "asks must be reversed for display so the lowest-priced ask is on top"
         );
+    }
+
+    // Empty input must not panic and must produce an empty display order.
+    #[test]
+    fn empty_inputs_produce_empty_output() {
+        let empty: Vec<OrderSummary> = vec![];
+        assert!(bids_in_display_order(&empty).is_empty());
+        assert!(asks_in_display_order(&empty).is_empty());
     }
 }

--- a/src/output/clob/books.rs
+++ b/src/output/clob/books.rs
@@ -38,6 +38,7 @@ pub fn print_order_book(
                 let rows: Vec<Row> = result
                     .bids
                     .iter()
+                    .rev()
                     .map(|o| Row {
                         price: o.price.to_string(),
                         size: o.size.to_string(),
@@ -56,6 +57,7 @@ pub fn print_order_book(
                 let rows: Vec<Row> = result
                     .asks
                     .iter()
+                    .rev()
                     .map(|o| Row {
                         price: o.price.to_string(),
                         size: o.size.to_string(),
@@ -157,4 +159,104 @@ pub fn print_last_trades_prices(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use polymarket_client_sdk_v2::clob::types::TickSize;
+    use polymarket_client_sdk_v2::clob::types::response::{OrderBookSummaryResponse, OrderSummary};
+    use polymarket_client_sdk_v2::types::{B256, Decimal, U256};
+    use rust_decimal_macros::dec;
+
+    /// Build a minimal `OrderBookSummaryResponse` with caller-supplied bids and asks.
+    /// The bids are provided in WORST-first order (ascending price) and asks in
+    /// WORST-first order (descending price), which is what a naïve API response might
+    /// contain and what the bug causes to be printed.
+    fn make_book(
+        bids: Vec<OrderSummary>,
+        asks: Vec<OrderSummary>,
+    ) -> OrderBookSummaryResponse {
+        OrderBookSummaryResponse::builder()
+            .market(B256::ZERO)
+            .asset_id(U256::ZERO)
+            .timestamp(Utc::now())
+            .min_order_size(dec!(1))
+            .neg_risk(false)
+            .tick_size(TickSize::Hundredth)
+            .bids(bids)
+            .asks(asks)
+            .build()
+    }
+
+    fn make_order(price: Decimal, size: Decimal) -> OrderSummary {
+        OrderSummary::builder().price(price).size(size).build()
+    }
+
+    /// Returns the price strings in the order that `print_order_book` would render them,
+    /// mirroring the exact `.iter().rev().map(|o| o.price.to_string())` chain used in the
+    /// production function.
+    fn rendered_bid_prices(book: &OrderBookSummaryResponse) -> Vec<String> {
+        book.bids.iter().rev().map(|o| o.price.to_string()).collect()
+    }
+
+    fn rendered_ask_prices(book: &OrderBookSummaryResponse) -> Vec<String> {
+        book.asks.iter().rev().map(|o| o.price.to_string()).collect()
+    }
+
+    /// The first bid shown must be the BEST bid (highest price = 0.50).
+    /// The current code iterates in insertion order without sorting, so it
+    /// renders 0.30 first — causing this test to FAIL on unpatched code.
+    #[test]
+    fn bids_rendered_best_price_first() {
+        // Bids inserted worst-to-best (ascending price), as might come from the API.
+        let book = make_book(
+            vec![
+                make_order(dec!(0.30), dec!(100)),
+                make_order(dec!(0.40), dec!(100)),
+                make_order(dec!(0.50), dec!(100)),
+            ],
+            vec![
+                make_order(dec!(0.50), dec!(100)),
+                make_order(dec!(0.60), dec!(100)),
+                make_order(dec!(0.70), dec!(100)),
+            ],
+        );
+
+        let bid_prices = rendered_bid_prices(&book);
+        assert_eq!(
+            bid_prices[0], "0.50",
+            "first rendered bid must be the best (highest) bid price 0.50, got {} \
+             — bids are printed in insertion order without sorting",
+            bid_prices[0]
+        );
+    }
+
+    /// The first ask shown must be the BEST ask (lowest price = 0.50).
+    /// Current code iterates in insertion order — FAILS when asks are stored
+    /// worst-first (descending price).
+    #[test]
+    fn asks_rendered_best_price_first() {
+        // Asks inserted worst-to-best (descending price), as might come from the API.
+        let book = make_book(
+            vec![
+                make_order(dec!(0.30), dec!(100)),
+                make_order(dec!(0.40), dec!(100)),
+                make_order(dec!(0.50), dec!(100)),
+            ],
+            vec![
+                make_order(dec!(0.70), dec!(100)),
+                make_order(dec!(0.60), dec!(100)),
+                make_order(dec!(0.50), dec!(100)),
+            ],
+        );
+
+        let ask_prices = rendered_ask_prices(&book);
+        assert_eq!(
+            ask_prices[0], "0.50",
+            "first rendered ask must be the best (lowest) ask price 0.50, got {} \
+             — asks are printed in insertion order without sorting",
+            ask_prices[0]
+        );
+    }
 }


### PR DESCRIPTION
## The change

Two `.rev()` calls — one on the bids iterator, one on asks — in `src/output/clob/books.rs`. The Polymarket CLOB API returns bids in ascending-price order (worst bid first) and asks in descending-price order (worst ask first), so iterating straight into `tabled::Table` buries the best prices at the bottom of each section. The ordering is now extracted into two small `super`-visible helpers (`bids_in_display_order`, `asks_in_display_order`) used by `print_order_book`, so the tests can exercise the production ordering directly without re-implementing it inline. JSON output, the type definitions, and every other display path are untouched.

```diff
@@ pub fn print_order_book(
+fn bids_in_display_order(bids: &[OrderSummary]) -> Vec<&OrderSummary> {
+    bids.iter().rev().collect()
+}
+
+fn asks_in_display_order(asks: &[OrderSummary]) -> Vec<&OrderSummary> {
+    asks.iter().rev().collect()
+}
@@
-                let rows: Vec<Row> = result
-                    .bids
-                    .iter()
+                let rows: Vec<Row> = bids_in_display_order(&result.bids)
+                    .into_iter()
                     .map(|o| Row { ... })
                     .collect();
@@
-                let rows: Vec<Row> = result
-                    .asks
-                    .iter()
+                let rows: Vec<Row> = asks_in_display_order(&result.asks)
+                    .into_iter()
                     .map(|o| Row { ... })
                     .collect();
```

## Empirical verification (local, Windows + stable rustc 1.96.0)

Three unit tests are added to `src/output/clob/books.rs`. Each calls a production helper directly — there is no `.iter().rev()` chain in the test body, so the assertion fails if the helper stops reversing.

Running the full books module tests on the branch as it stands (both helpers reverse):

```
running 3 tests
test output::clob::books::tests::empty_inputs_produce_empty_output ... ok
test output::clob::books::tests::asks_in_display_order_puts_best_ask_first ... ok
test output::clob::books::tests::bids_in_display_order_puts_best_bid_first ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 82 filtered out
```

Then deleting `.rev()` only from `bids_in_display_order` (asks helper kept reversing) and re-running:

```
running 3 tests
test output::clob::books::tests::empty_inputs_produce_empty_output ... ok
test output::clob::books::tests::asks_in_display_order_puts_best_ask_first ... ok
test output::clob::books::tests::bids_in_display_order_puts_best_bid_first ... FAILED

failures:

---- output::clob::books::tests::bids_in_display_order_puts_best_bid_first stdout ----

thread '...' panicked at src\output\clob\books.rs:196:9:
assertion `left == right` failed: bids must be reversed for display so the highest-priced bid is on top
  left: [0.30, 0.40, 0.50]
 right: [0.50, 0.40, 0.30]

test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 82 filtered out
```

And, symmetric, with `.rev()` removed only from `asks_in_display_order` (bids helper kept reversing):

```
running 3 tests
test output::clob::books::tests::empty_inputs_produce_empty_output ... ok
test output::clob::books::tests::bids_in_display_order_puts_best_bid_first ... ok
test output::clob::books::tests::asks_in_display_order_puts_best_ask_first ... FAILED

failures:

---- output::clob::books::tests::asks_in_display_order_puts_best_ask_first stdout ----

thread '...' panicked at src\output\clob\books.rs:214:9:
assertion `left == right` failed: asks must be reversed for display so the lowest-priced ask is on top
  left: [0.70, 0.60, 0.50]
 right: [0.50, 0.60, 0.70]

test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 82 filtered out
```

That is the property each test actually pins.

## Compliance

- `cargo fmt --check` — exit 0
- `cargo clippy --all-targets -- -D warnings` — exit 0
- `cargo test` — full suite: 84 passed | 1 failed; the one failure (`commands::upgrade::tests::detect_target_returns_valid_triple` with `Unsupported platform: windows/x86_64`) reproduces unchanged on `main` and is unrelated to this PR (`detect_target` for Windows in `src/commands/upgrade.rs`).

## Reproduction in the wild

Reproduced against the BTC `$150k by June 30` market and 2 other high-volume markets — API ordering is consistent (bids ascending, asks descending), and the table layout buries the best prices at the bottom in every case. The non-obvious ordering is also documented in [Polymarket/rs-clob-client#330](https://github.com/Polymarket/rs-clob-client/issues/330) for the V1 Rust SDK.

JSON output (`OutputFormat::Json`) keeps the API order so programmatic consumers stay backward-compatible — this is purely the human-facing table.

Closes #75.
