### PR TITLE
Fix events list default closed filter

### DIFF
--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -73,18 +73,8 @@ pub async fn execute(client: &gamma::Client, args: EventsArgs, output: OutputFor
             ascending,
             tag,
         } => {
-            let resolved_closed = closed.or_else(|| active.map(|a| !a));
-
-            let request = EventsRequest::builder()
-                .limit(limit)
-                .maybe_closed(resolved_closed)
-                .maybe_offset(offset)
-                .ascending(ascending)
-                .maybe_tag_slug(tag)
-                // EventsRequest::order is Vec<String>; into_iter on Option yields 0 or 1 items.
-                .order(order.into_iter().collect())
-                .build();
-
+            let request =
+                build_events_list_request(active, closed, limit, offset, order, ascending, tag);
             let events = client.events(&request).await?;
             print_events(&events, &output)?;
         }
@@ -111,4 +101,55 @@ pub async fn execute(client: &gamma::Client, args: EventsArgs, output: OutputFor
     }
 
     Ok(())
+}
+
+fn build_events_list_request(
+    active: Option<bool>,
+    closed: Option<bool>,
+    limit: i32,
+    offset: Option<i32>,
+    order: Option<String>,
+    ascending: bool,
+    tag: Option<String>,
+) -> EventsRequest {
+    let resolved_closed = Some(closed.unwrap_or_else(|| active.map(|a| !a).unwrap_or(false)));
+
+    EventsRequest::builder()
+        .limit(limit)
+        .maybe_closed(resolved_closed)
+        .maybe_offset(offset)
+        .ascending(ascending)
+        .maybe_tag_slug(tag)
+        // EventsRequest::order is Vec<String>; into_iter on Option yields 0 or 1 items.
+        .order(order.into_iter().collect())
+        .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn events_list_resolves_closed_filter() {
+        assert_eq!(
+            build_events_list_request(None, None, 25, None, None, false, None).closed,
+            Some(false)
+        );
+        assert_eq!(
+            build_events_list_request(None, Some(true), 25, None, None, false, None).closed,
+            Some(true)
+        );
+        assert_eq!(
+            build_events_list_request(Some(true), None, 25, None, None, false, None).closed,
+            Some(false)
+        );
+        assert_eq!(
+            build_events_list_request(Some(false), None, 25, None, None, false, None).closed,
+            Some(true)
+        );
+        assert_eq!(
+            build_events_list_request(Some(true), Some(true), 25, None, None, false, None).closed,
+            Some(true)
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Make `events list` send `closed=false` by default when neither `--closed` nor `--active` is provided.
- Keep explicit `--closed` behavior and the existing `--active` to `closed` mapping.
- Add a focused unit test for the resolved `closed` filter, covering default behavior, explicit `--closed`, `--active true`, `--active false`, and `--closed` precedence.

## Why
Gamma `/events` currently returns closed events when the `closed` query parameter is omitted. The CLI should request open events by default.

Fixes #71

## Validation
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI query-parameter default for events listing; no auth or data-path changes.
> 
> **Overview**
> **`events list` now always sends an explicit `closed` query parameter** instead of omitting it when neither `--closed` nor `--active` is set. The default is **`closed=false`** (open events), matching expected CLI behavior when Gamma returns closed events if `closed` is missing.
> 
> List request construction is moved into **`build_events_list_request`**, which resolves filters as: explicit `--closed` wins; otherwise `--active` maps to `closed = !active`; otherwise **`false`**. **`--active` / `--closed` combinations** from before are preserved (e.g. `--active` alone still implies `closed=false`).
> 
> A **unit test** (`events_list_resolves_closed_filter`) locks in those resolution cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b63a0cdaa8c2f5aa2c50c9db9946aa325975805. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->